### PR TITLE
Fixes ownmine_fixownership

### DIFF
--- a/.ownmine.d/ownmine.zsh
+++ b/.ownmine.d/ownmine.zsh
@@ -21,7 +21,7 @@ function ownmine_debug_off() {
 # Fixes ownership after sync
 function ownmine_fixownership() {
     sudo chmod -R 770 $1
-    sudo chown $OWNMINE_LOCAL_USER:$OWNMINE_LOCAL_USER $1
+    sudo chown -R $OWNMINE_LOCAL_USER:$OWNMINE_LOCAL_USER $1
 }
 
 


### PR DESCRIPTION
The `chown` command inside `ownmine_fixownership` function must be applied recursivly in order to work properly