### PR TITLE
Ownmine fixownership bug fixes

### DIFF
--- a/.ownmine.d/ownmine.zsh
+++ b/.ownmine.d/ownmine.zsh
@@ -247,7 +247,7 @@ function ownmine() {
             ownmine backup
             ownmine sync
             ownmine_server_pull
-            ownmine_fixownership $OWNMINE_SAMBA_FOLDER_MAIN
+            ownmine_fixownership $OWNMINE_LOCAL_SERVER
             ;;
         ("exit")
             ownmine stop

--- a/.ownmine.d/ownmine.zsh
+++ b/.ownmine.d/ownmine.zsh
@@ -21,7 +21,7 @@ function ownmine_debug_off() {
 # Fixes ownership after sync
 function ownmine_fixownership() {
     sudo chmod -R 770 $1
-    sudo chown $OWNMINE_LOCAL_USER:$OWNMINE_LOCAL_USER $1
+    sudo chown -R $OWNMINE_LOCAL_USER:$OWNMINE_LOCAL_USER $1
 }
 
 


### PR DESCRIPTION
The function `ownmine_fixownership` was being applied to the incorrect folder (it was being applied to the backup server folder instead of the minecraft folder)
The command `chown` inside said function must be applied recursively